### PR TITLE
CI: Fix macOS runners trying to use x64

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,7 +22,6 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
         arch:
           - x64
         include:
@@ -32,6 +31,15 @@ jobs:
           - os: ubuntu-latest
             version: '1'
             arch: x86
+          - os: macos-latest
+            version: '1.10'
+            arch: default
+          - os: macos-latest
+            version: '1'
+            arch: default
+          - os: macos-latest
+            version: 'nightly'
+            arch: default
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
GitHub Actions now errors when trying to run macOS runers
with `x64` as `arch`.  Fix this by allowing them to
use their default architecture.
